### PR TITLE
Cron job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+docker
+cron_job

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7.7
+COPY . /StopSpot_Data_Pipeline
+RUN python -m pip install \
+        pipenv \
+        parse \
+        realpython-reader \
+        pandas \
+        sqlalchemy \
+        psycopg2

--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ below.
   b. `python3 main.py --help`: See the instructions for use as a command.  
 3) `exit`: Close the virtual environment
 
+### Setup Docker environment
+
 To setup the docker environment you can do so using the script ```docker/build```. This bash script can be executed by the following command ```./build``` while in the docker directory. This script will simply build the image for future docker containers. If you wish to connect to a docker container with the ```stop_spot``` image and interact with it using a shell you can use the ```docker/connect``` script by running it in a similar fashion to the ```docker/build``` script. The ```docker/connect``` script will create a new container everytime, if you wish to connect an existing container you can do so with the following command.
 
 ```docker exec -it container_id bash```
+
+
+### Setup Cron Job
 
 To create a cron job, use the ```cron_job/create_cron_job``` script to create a cron job which will process new data every 24 hours. The script is a simple bash script which puts the contents of ```cron_job/cron_job_params``` into crontab. To run the script simply type ```./create_cron_job``` while in the ```cron_job``` directory. If you want to change the time interval for which the cron job runs you can edit the ```cron_job/cron_job_params``` file and rerun the ```cron_job/create_cron_job``` script. By default the script is set to start a container of the application and process the next days data at 4am.
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ below.
 2) Executing the program.  
   a. `python3 main.py`: Start the program's CLI menu.  
   b. `python3 main.py --help`: See the instructions for use as a command.  
-3) `exit`: Close the virtual environment.
+3) `exit`: Close the virtual environment
 
-Alternatively, place the below into the system's crontab to automatically process new data every 24 hours.
-Again, this does require the First Time Execution to have already occurred.  
-`TODO: place the crontab line here.`
+To setup the docker environment you can do so using the script ```docker/build```. This bash script can be executed by the following command ```./build``` while in the docker directory. This script will simply build the image for future docker containers. If you wish to connect to a docker container with the ```stop_spot``` image and interact with it using a shell you can use the ```docker/connect``` script by running it in a similar fashion to the ```docker/build``` script. The ```docker/connect``` script will create a new container everytime, if you wish to connect an existing container you can do so with the following command.
+
+```docker exec -it container_id bash```
+
+To create a cron job, use the ```cron_job/create_cron_job``` script to create a cron job which will process new data every 24 hours. The script is a simple bash script which puts the contents of ```cron_job/cron_job_params``` into crontab. To run the script simply type ```./create_cron_job``` while in the ```cron_job``` directory. If you want to change the time interval for which the cron job runs you can edit the ```cron_job/cron_job_params``` file and rerun the ```cron_job/create_cron_job``` script. By default the script is set to start a container of the application and process the next days data at 4am.
+
+Again, this does require the First Time Execution to have already occurred as the connection details within ```assets/config.json``` are necessary to process the next days data. Additionally, you must build the docker image using the script ```docker/build``` as the cron job will start a docker container to process the next days data.  
 
 ### Using the Client
 

--- a/cron_job/create_cron_job
+++ b/cron_job/create_cron_job
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+crontab < $PWD/cron_job_params
+
+echo -e "-------------------Crontab Contents Below-------------------\n"
+crontab -l

--- a/cron_job/cron_job_params
+++ b/cron_job/cron_job_params
@@ -1,0 +1,10 @@
+# .---------------- minute (0 - 59)
+# | .------------- hour (0 - 23)
+# | | .---------- day of month (1 - 31)
+# | | | .------- month (1 - 12)
+# | | | | .---- day of week (0 - 6) (Sunday=0 or 7)
+# | | | | |
+# * * * * * command
+
+9 21 * * * docker run -d --rm stop_spot python3 StopSpot_Data_Pipeline/main.py --help
+

--- a/cron_job/cron_job_params
+++ b/cron_job/cron_job_params
@@ -6,5 +6,5 @@
 # | | | | |
 # * * * * * command
 
-9 21 * * * docker run -d --rm stop_spot python3 StopSpot_Data_Pipeline/main.py --help
+0 4 * * * docker run -d --rm stop_spot python3 StopSpot_Data_Pipeline/main.py --daily
 

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t stop_spot ..

--- a/docker/connect
+++ b/docker/connect
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --entrypoint "/bin/bash" -it stop_spot


### PR DESCRIPTION
This PR addresses issue #52. Within the cron_job directory I have a file which can be edited to change the value for which the cron job should run. I made a script (create_cron_job) which writes the contents of this cron_job_params configuration file to crontab. Originally we wanted to have the cron job run a script which would start the container of aperture and the pipeline but I had some weirdness with relative path stuff. Alternatively, since the script would consist of a single command anyway, I just directly put the command into the cron_job_params configuration file. The command in the cron_job_params configuration file will pass the --daily flag while running the application which should process the next days data once Dan's changes get in and provided that the config.json file in the assets directory is configured before using the create_cron_job script. I also added some docker stuff to the project which consists of a modified Dockerfile that Nelson was working on. I also added a .dockerignore file which will ignore certain directories when copying the contents of the project into the docker container. Curious to know how people feel about the project structure that I have made here. Oh and some README stuff was added for docker and the cron job.