### PR TITLE
fixed shell scripts

### DIFF
--- a/BrowseContainer.sh
+++ b/BrowseContainer.sh
@@ -11,6 +11,6 @@
 sudo docker run -it \
 	--name pipeline \
 	--entrypoint "/bin/bash" \
-	--mount type=bind,source="$(pwd)"/pipeline,target=/StopSpot_Data_Pipeline \
+	--mount type=bind,source="$(pwd)"/pipeline,target=/pipeline \
 	--rm \
 	cli

--- a/docker/ConfigureDocker.sh
+++ b/docker/ConfigureDocker.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Create the docker "image"; this is the tempate that containers are created from.
 # Both images are tagged with pipetag; this will help prevent multiple overlapping instances from running.
 # This file should create both images
@@ -13,4 +12,4 @@ sudo docker build -t cli \
 # GUI
 # Dockerfile is located in subdirectory dockerfiles\gui
 sudo docker build -t gui \
-	./CLI/
+	./GUI/


### PR DESCRIPTION
browse container.sh should have set the target folder as "pipeline", but wasn't; this has been fixed.

shell scripts were edited in windows and made them break in linux. This has been fixed.